### PR TITLE
Adds retrieve payment methods customer endpoint

### DIFF
--- a/lib/stripe_mock/request_handlers/payment_methods.rb
+++ b/lib/stripe_mock/request_handlers/payment_methods.rb
@@ -58,9 +58,9 @@ module StripeMock
         allowed_params = [:customer]
 
         id = method_url.match(route)[1]
-  
+
         assert_existence :customer, params[:customer], customers[stripe_account][params[:customer]]
-  
+
         payment_method = assert_existence :payment_method, id, payment_methods[id]
         payment_methods[id] = Util.rmerge(payment_method, params.select { |k, _v| allowed_params.include?(k) })
         payment_methods[id].clone

--- a/lib/stripe_mock/request_handlers/payment_methods.rb
+++ b/lib/stripe_mock/request_handlers/payment_methods.rb
@@ -58,11 +58,19 @@ module StripeMock
         allowed_params = [:customer]
 
         id = method_url.match(route)[1]
-
-        assert_existence :customer, params[:customer], customers[stripe_account][params[:customer]]
-
+  
+        customer = assert_existence :customer, params[:customer], customers[stripe_account][params[:customer]]
+  
         payment_method = assert_existence :payment_method, id, payment_methods[id]
         payment_methods[id] = Util.rmerge(payment_method, params.select { |k, _v| allowed_params.include?(k) })
+  
+        customer[:sources] ||= { data: [], total_count: 0 }
+  
+        unless customer[:sources][:data].any? { |source| source[:id] == id }
+          customer[:sources][:data] << payment_methods[id]
+          customer[:sources][:total_count] += 1
+        end
+  
         payment_methods[id].clone
       end
 

--- a/lib/stripe_mock/request_handlers/payment_methods.rb
+++ b/lib/stripe_mock/request_handlers/payment_methods.rb
@@ -59,18 +59,10 @@ module StripeMock
 
         id = method_url.match(route)[1]
   
-        customer = assert_existence :customer, params[:customer], customers[stripe_account][params[:customer]]
+        assert_existence :customer, params[:customer], customers[stripe_account][params[:customer]]
   
         payment_method = assert_existence :payment_method, id, payment_methods[id]
         payment_methods[id] = Util.rmerge(payment_method, params.select { |k, _v| allowed_params.include?(k) })
-  
-        customer[:sources] ||= { data: [], total_count: 0 }
-  
-        unless customer[:sources][:data].any? { |source| source[:id] == id }
-          customer[:sources][:data] << payment_methods[id]
-          customer[:sources][:total_count] += 1
-        end
-  
         payment_methods[id].clone
       end
 

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -535,4 +535,27 @@ shared_examples 'Customer API' do
     customer = Stripe::Customer.retrieve("test_customer_update")
     expect(customer.discount).to be nil
   end
+
+  it "retrieves a stripe customers payment method" do
+    payment_method = Stripe::PaymentMethod.create({
+      type: 'card',
+      card: {
+        number: '4242424242424242',
+        exp_month: 12,
+        exp_year: 2024,
+        cvc: 123
+      }
+    })
+
+    customer = Stripe::Customer.create({
+      email: 'johnny@appleseed.com',
+      invoice_settings: {
+        default_payment_method: payment_method.id
+      },
+      description: "a description"
+    })
+
+    retrieved_payment_method = Stripe::Customer.retrieve_payment_method(customer.id, payment_method.id)
+    expect(retrieved_payment_method.id).to eq(payment_method.id)
+  end
 end

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -565,7 +565,6 @@ shared_examples 'Customer API' do
       description: "a description"
     })
 
-    expect { customer.source }.to raise_error
     retrieved_payment_method = Stripe::Customer.retrieve_payment_method(customer.id, customer.sources.data.first.id)
     expect(retrieved_payment_method.id).to eq(customer.sources.data.first.id)
   end

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -549,11 +549,10 @@ shared_examples 'Customer API' do
 
     customer = Stripe::Customer.create({
       email: 'johnny@appleseed.com',
-      invoice_settings: {
-        default_payment_method: payment_method.id
-      },
       description: "a description"
     })
+
+    payment_method.attach(customer: customer.id)
 
     retrieved_payment_method = Stripe::Customer.retrieve_payment_method(customer.id, payment_method.id)
     expect(retrieved_payment_method.id).to eq(payment_method.id)

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -557,4 +557,17 @@ shared_examples 'Customer API' do
     retrieved_payment_method = Stripe::Customer.retrieve_payment_method(customer.id, payment_method.id)
     expect(retrieved_payment_method.id).to eq(payment_method.id)
   end
+
+  it "retrives a stripe customers payment method with a default card" do
+    customer = Stripe::Customer.create({
+      email: 'johnny@appleseed.com',
+      source: gen_card_tk,
+      description: "a description"
+    })
+
+    expect { customer.source }.to raise_error
+    retrieved_payment_method = Stripe::Customer.retrieve_payment_method(customer.id, customer.sources.data.first.id)
+    expect(retrieved_payment_method.id).to eq(customer.sources.data.first.id)
+  end
+
 end


### PR DESCRIPTION
This PR introduces a new request handler to simulate retrieving a payment method for a customer in the Stripe mock environment. The new handler is registered via the `Customers.included` callback using the route:

```
get /v1/customers/([^/]+)/payment_methods/([^/]+)
```

The corresponding method, `retrieve_payment_method`, extracts the customer ID and payment method ID from the URL, validates the existence of the customer, and then searches for the payment method within the customer's stored sources. If the payment method is not found, it raises an appropriate error.

I found based on the docs that to test you need to run the following:
```
$ bundle install
$ bundle exec rspec
```
However this led to a lot of errors.
To test the specific functions added you can use the following
```
bundle exec rspec spec/instance_spec.rb
```