### PR TITLE
Add retrieve payment methods

### DIFF
--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -189,6 +189,7 @@ module StripeMock
           metadata: {},
           type: 'card'
         )
+        base
       end
 
       def retrieve_payment_method(route, method_url, params, headers)

--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -164,30 +164,15 @@ module StripeMock
 
       # Helper to wrap a legacy source into a temporary PaymentMethod object
       def legacy_source_to_payment_method(source)
-        {
+        base = Data.mock_payment_method({}) || {}
+        base.merge(
           id: source[:id],
           object: 'payment_method',
-          allow_redisplay: 'unspecified',
-          billing_details: {
-            address: {
-              city: nil,
-              country: nil,
-              line1: nil,
-              line2: nil,
-              postal_code: nil,
-              state: nil
-            },
-            email: nil,
-            name: nil,
-            phone: nil,
-          },
-          card: source.clone,  # embed the legacy source data as the card subobject
+          card: source.clone,    # overwrite with the legacy source as the card subobject
           created: Time.now.to_i,
           customer: source[:customer],
-          livemode: false,
-          metadata: {},
           type: 'card'
-        }
+        )
       end
 
       def retrieve_payment_method(route, method_url, params, headers)

--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -178,7 +178,7 @@ module StripeMock
         if customer[:sources] && customer[:sources][:data]
           source = customer[:sources][:data].detect { |src| src[:id] == payment_method_id }
           if source && source[:customer] == customer_id
-            return source
+            return source.is_a?(Hash) ? source.clone : source.to_h
           end
         end
 

--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -164,32 +164,12 @@ module StripeMock
 
       # Helper to wrap a legacy source into a temporary PaymentMethod object
       def legacy_source_to_payment_method(source)
-        base = Data.mock_payment_method({}) || {}
-        base.merge(
-          id: source[:id],
-          object: 'payment_method',
-          allow_redisplay: 'unspecified',
-          billing_details: {
-            address: {
-              city: nil,
-              country: nil,
-              line1: nil,
-              line2: nil,
-              postal_code: nil,
-              state: nil
-            },
-            email: nil,
-            name: nil,
-            phone: nil
-          },
-          card: source.clone,    # overwrite with the legacy source as the card subobject
-          created: Time.now.to_i,
-          customer: source[:customer],
-          livemode: false,
-          metadata: {},
-          type: 'card'
-        )
-        base
+        Data.mock_payment_method({id: source[:id],
+        card: source.clone,    # overwrite with the legacy source as the card subobject
+        created: Time.now.to_i,
+        customer: source[:customer],
+        type: 'card'}) || {}
+
       end
 
       def retrieve_payment_method(route, method_url, params, headers)

--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -168,9 +168,25 @@ module StripeMock
         base.merge(
           id: source[:id],
           object: 'payment_method',
+          allow_redisplay: 'unspecified',
+          billing_details: {
+            address: {
+              city: nil,
+              country: nil,
+              line1: nil,
+              line2: nil,
+              postal_code: nil,
+              state: nil
+            },
+            email: nil,
+            name: nil,
+            phone: nil
+          },
           card: source.clone,    # overwrite with the legacy source as the card subobject
           created: Time.now.to_i,
           customer: source[:customer],
+          livemode: false,
+          metadata: {},
           type: 'card'
         )
       end


### PR DESCRIPTION
I ended up needing to create a new mocked object to match with stripes implementation. This change mocks the payment method object and fills in the card details so that the hash can be accessed by our serializer. We needed the full payment method object to be returned to have the object in our serializer.

To test:

```
Bundle install
bundle rspec spec/instance.rb
```

This Branch was tested against our own external test suite and passed.